### PR TITLE
Fix template syntax in timebox markdown file

### DIFF
--- a/pages/template___timebox.md
+++ b/pages/template___timebox.md
@@ -1,6 +1,6 @@
 - # Time Box
-  template: time_box
-  template-including-parent: false
+  template:: time_box
+  template-including-parent:: false
 	- ## Meta
 	  type:: timebox
 	  tags:: timebox


### PR DESCRIPTION
Syntax was incorrect, so Logseq wouldn't recognise this as a template.